### PR TITLE
Remove app_name string

### DIFF
--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">InfiniteIndicator</string>
 </resources>


### PR DESCRIPTION
App_name string be a problem on  merging manifests. Give error duplicate resources. Libraries don't need app_name string.
